### PR TITLE
Do not override sane suffixes for hetero-lists

### DIFF
--- a/src/main/webapp/script.js
+++ b/src/main/webapp/script.js
@@ -23,17 +23,23 @@
     }
 
 
-    // patch hetero-list-container handling to capture name before hudson-behavior.js kicks in (for Jenkins < 1.473)
+    // patch hetero-list-container handling to capture name before hudson-behavior.js kicks in
+    // in Jenkins 1.473 and newer the suffix is already set in hetero-list.js
     pre(".hetero-list-container", function(e) {
         var proto = $(e).down("DIV.prototypes");
         var d = proto.down();
-        proto.next().setAttribute('suffix',d.getAttribute("name"));
+        if (!proto.next().hasAttribute('suffix')) {
+            proto.next().setAttribute('suffix',d.getAttribute("name"));
+        }
     });
 
     // then post process to add @suffix to the button
     post(".hetero-list-container", function(e) {
         var b = $(e.lastChild);
-        b.getElementsByTagName("button")[0].setAttribute("suffix", b.getAttribute("suffix"));
+        var button = b.getElementsByTagName("button")[0]
+        if (!button.hasAttribute('suffix')) {
+            button.setAttribute("suffix", b.getAttribute("suffix"));
+        }
     });
 })();
 


### PR DESCRIPTION
Review needed.

The original code wipes out `suffix` overwriting it by a value of name attribute that is not present, effectively throwing away the suffixes like `publisher` or `builder`. Moreover, the part that assigns numbers for colliding element names does not handle this situation correctly as the value of `suffix` becomes `""` in firefox 18 and `"null"` in chromium 26 and the corresponding paths can look like `"/hetero-list-add[]"`(ff) or `"/hetero-list-add[null]"`(chromium).

I propose to stick with the suffixes attached in `hetero-list.js` to avoid this incompatibility and have more descriptive paths (`/hetero-list-add[publisher]`) at the same time.
