### PR TITLE
Correct condition for Text object

### DIFF
--- a/src/main/webapp/script.js
+++ b/src/main/webapp/script.js
@@ -114,7 +114,7 @@ Behaviour.addLoadEvent(function(){
 
                     if (name==null) {
                         s = s.parentNode.previousSibling;
-                        if (s!=null && $(s).hasClassName('repeatable-insertion-point'))
+                        if (s!=null && !(s instanceof Text) && $(s).hasClassName('repeatable-insertion-point'))
                             name = "hetero-list-add";
                     }
                 }


### PR DESCRIPTION
Variable s could be an isntance of Text object so hasClassName is not applicable and javascript fails with message "TypeError: $(...).hasClassName is not a function". Due this fail a job configuration can not be saved (I catched it for Plot plugin)
