### PR TITLE
[JENKINS-37276] Path atributes can change values if reordered

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/form-element-path.js
+++ b/src/main/resources/org/jenkinsci/plugins/form-element-path.js
@@ -165,7 +165,7 @@ Behaviour.addLoadEvent(function(){
                 function child(v,i) {
                     var suffix=null;
                     var newKey=key;
-                    if (v.getAttribute("name")=="publisher") {
+                    if (v.parentNode.className && v.parentNode.className.indexOf("one-each")>-1 && v.parentNode.className.indexOf("honor-order")>-1) {
                         suffix = v.getAttribute("descriptorId").split(".").pop()
                     } else if (v.getAttribute("type")=="radio"){
                         suffix = v.value

--- a/src/main/resources/org/jenkinsci/plugins/form-element-path.js
+++ b/src/main/resources/org/jenkinsci/plugins/form-element-path.js
@@ -165,7 +165,9 @@ Behaviour.addLoadEvent(function(){
                 function child(v,i) {
                     var suffix=null;
                     var newKey=key;
-                    if (v.getAttribute("type")=="radio"){
+                    if (v.getAttribute("name")=="publisher") {
+                        suffix = v.getAttribute("descriptorId").split(".").pop()
+                    } else if (v.getAttribute("type")=="radio"){
                         suffix = v.value
                         while (newKey.substring(0,8)=='removeme')
                             newKey = newKey.substring(newKey.indexOf('_',8)+1);


### PR DESCRIPTION
[JENKINS-37276](https://issues.jenkins-ci.org/browse/JENKINS-37276)

Whilst is relatively easy to no modify existing path attributes is not that easy not to generate duplicated path values with the current implementation based on numbers. So I have decided to generate the path value based on the descriptorID of the publisher. This way for a given publisher the path is always the same regardless the order on which they are added or the number of existing ones.

This PR is intended as a starting point, any suggestion, comment or bug is more than wellcome