### PR TITLE
update baseline so we do not depend on any detached plugins

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>3.43</version>
+    <version>4.13</version>
     <relativePath />
   </parent>
 
@@ -15,7 +15,8 @@
   <url>https://wiki.jenkins.io/display/JENKINS/Form+Element+Path+Plugin</url>
 
   <properties>
-    <jenkins.version>2.176.1</jenkins.version>
+    <!-- minimum LTS with no detached dependencies -->
+    <jenkins.version>2.190.1</jenkins.version>
     <java.level>8</java.level>
   </properties>
 


### PR DESCRIPTION
As this plugin depended on detached plugins installing it from the
outset in the ATH caused the trilead-api plugin to be installed, and
this could be an older version that was required by some plugins that we
actually want to test.  This causes an issue as the plugins are not hot
installable as the update to trilead-api requires a restart - which does
not happen and the ATH fails.

Observed in the Git plugin tests.

@MarkEWaite @jglick 